### PR TITLE
Add a timeout when waiting for RX

### DIFF
--- a/source/keysta.c
+++ b/source/keysta.c
@@ -78,6 +78,7 @@ enum enum_state { IDLE_START = 0, IDLE_WAIT_REL,
     TX_PARITY, TX_STOP, TX_AFTER_STOP, TX_END } ;
 
 volatile unsigned char kbd_state;
+volatile unsigned long tick;
 
 static volatile unsigned char   rx_byte;
 static volatile unsigned char   tx_byte;
@@ -133,7 +134,7 @@ static void timerAction(void)
 {
     /* restart timer */
     outp(COUNT_UP, TCNT0);  /* value counts up from this to zero */
-    
+    tick++;
 
     if (kbd_state < IDLE_END) { // start, wait_rel or ready to tx
         dataHigh();

--- a/source/ps2main.c
+++ b/source/ps2main.c
@@ -65,6 +65,8 @@ static int temp_a, temp_b;
 static int i, j;
 static int keyval=0;
 
+extern volatile unsigned long tick;
+
 // waiting RX, for led indicate key like capslock, because, fix bug of fast down/up like macro/dualaction.
 static bool _isWaitingRx = false;
 static void setWaitingRx(bool xIsWait);
@@ -168,6 +170,7 @@ static void keymap_init(void)
 void setWaitingRx(bool xIsWait){
 	if(xIsWait) {
 		keyval = SPLIT_KEY;
+		tick = 0;
 	}else{
 		isAlreadyPushedWaitingRx = false;
 	}
@@ -589,7 +592,8 @@ void ps2_main(void){
     sei();
 
     for(;;){
-
+        if (isWaitingRx() && tick > RX_TIMEOUT)
+            setWaitingRx(false);
         processRxPs2();
         processTxPs2();
 

--- a/source/ps2main.h
+++ b/source/ps2main.h
@@ -48,6 +48,7 @@
 #define PS2_REPEAT_SPEED_SET_MIDD	2
 #define PS2_REPEAT_SPEED_SET_LOW	3
 
+#define RX_TIMEOUT  20
 
 uint8_t ps2_repeat_speed;
 void ps2_main(void);


### PR DESCRIPTION
When setting some keys, we sometimes expect receive a command from the
host (e.g. caps lock). Some host send commands to set LED status during
set _or_ break.

For example, when it comes to turn on a LED host commands are sent just
after the key is pushed and nothing when released. The second time the key
is pushed no command are sent but when the key is released commands are
sent.

Corrent firmware does not handle this and always expect a command from
the host after sending some set commands. In this situation firmware is
stuck waiting for some commands that won't come.

This patch adds a timeout when waiting for commands from host. If the
command is not received after RX_TIMEOUT (which is expressed as timer
tick) its not waited anymore.

Signed-off-by: Franck Jullien <franck.jullien@odyssee-systemes.fr>